### PR TITLE
feat: Naver Search Advisor 站点验证 meta 标签 + Yeti 爬虫识别

### DIFF
--- a/lib/bot-detector.ts
+++ b/lib/bot-detector.ts
@@ -21,6 +21,7 @@ export const BOT_PATTERNS: RegExp[] = [
   /yandexbot/i,
   /duckduckbot/i,
   /slurp/i, // Yahoo
+  /yeti/i, // Naver
 
   // Social media crawlers
   /facebookexternalhit/i,

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -27,6 +27,12 @@ export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://betterbagsm
 export const DEFAULT_OG_IMAGE = '/images/og-image.jpg';
 
 /**
+ * Naver Search Advisor 站点所有权验证码
+ * 公开信息（随 HTML 明文输出），非机密，无需环境变量
+ */
+export const NAVER_SITE_VERIFICATION = '902febe431ab2c1939298f861bafa0fcb52c9cd4';
+
+/**
  * 页面元数据文案（title/description 来自 locales JSON 的 metadata namespace）
  */
 export interface PageMetadata {
@@ -65,7 +71,16 @@ function getOgLocale(locale: Locale): string {
  * @returns Metadata 对象
  */
 export function generateHomeMetadata(locale: Locale, meta: PageMetadata): Metadata {
-  return generateGenericMetadata(locale, meta.title, meta.description, '');
+  return {
+    ...generateGenericMetadata(locale, meta.title, meta.description, ''),
+    // 站长平台所有权验证（渲染为 <meta name="naver-site-verification" .../>）
+    // 根 layout 使用本函数，全部 locale 首页的 head 均输出该标签
+    verification: {
+      other: {
+        'naver-site-verification': NAVER_SITE_VERIFICATION,
+      },
+    },
+  };
 }
 
 /**

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -246,6 +246,20 @@ describe('SEO 元数据配置', () => {
   });
 
   /**
+   * 站长平台验证标签（Naver Search Advisor 站点所有权验证）
+   */
+  describe('站长平台验证标签', () => {
+    it.each(locales)('%s 首页元数据应包含 naver-site-verification 验证码', (locale) => {
+      const metadata = generateHomeMetadata(locale, allMetadata[locale].home);
+      const other = metadata.verification?.other as Record<string, string> | undefined;
+
+      expect(other?.['naver-site-verification']).toBe(
+        '902febe431ab2c1939298f861bafa0fcb52c9cd4'
+      );
+    });
+  });
+
+  /**
    * 内容质量验证（全语言）
    */
   describe('内容质量验证', () => {

--- a/tests/properties/bot-detection.test.ts
+++ b/tests/properties/bot-detection.test.ts
@@ -23,6 +23,7 @@ describe('Property 4: Bot Detection Accuracy', () => {
     'WhatsApp/2.21.4.22',
     'Mozilla/5.0 (compatible; AhrefsBot/7.0)',
     'Mozilla/5.0 (compatible; SemrushBot/7)',
+    'Mozilla/5.0 (compatible; Yeti/1.1; +https://naver.me/spd)',
   ];
 
   // Normal browser User-Agents that MUST NOT be detected as bots


### PR DESCRIPTION
## 背景

Naver Search Advisor 提交 sitemap 前要求验证站点所有权：将指定的 meta 标签放入首页 `<head>`。

## 改动

- **`lib/metadata.ts`**: `generateHomeMetadata` 输出 `verification.other['naver-site-verification']`，Next.js Metadata API 渲染为 `<meta name="naver-site-verification" content="902febe431ab2c1939298f861bafa0fcb52c9cd4"/>`。根 layout 使用此函数，12 语首页（及继承的子页面）`<head>` 均带该标签
- **`lib/bot-detector.ts`**: 补充 Naver 爬虫 `Yeti` 的 UA 模式（原名单匹配不到，Naver 爬虫会被 geo 重定向逻辑影响），使其与 Googlebot 等待遇一致

## 测试（TDD）

- 12 语首页元数据验证码断言（`tests/metadata.test.ts`）
- Yeti UA 检测用例（`tests/properties/bot-detection.test.ts`）
- 全量 1429 通过 / 2 跳过；lint 无新增问题
- 本地 dev 实况验证：en/ko/zh 首页 HTML 均渲染该 meta 标签

## 合并后操作

1. 等 Vercel 生产部署完成
2. 到 Naver Search Advisor 点击「소유확인」完成验证
3. 提交 sitemap: `https://betterbagsmm.com/sitemap.xml`

注：本地 build 因网络环境无法完成字体下载（与本改动无关），build 验收以 Vercel 为准。

🤖 Generated with [Claude Code](https://claude.com/claude-code)