### PR TITLE
fix: BreadcrumbList 服务端渲染 item 为 undefined 无效网址(GSC 路径报错)

### DIFF
--- a/components/content/CertificationBadges.tsx
+++ b/components/content/CertificationBadges.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { FACTORY_INFO } from '@/components/seo/ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * CertificationBadges 组件属性

--- a/components/content/FactoryMapEmbed.tsx
+++ b/components/content/FactoryMapEmbed.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useLocale, useTranslations } from 'next-intl';
-import { FACTORY_INFO } from '@/components/seo/ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * 工厂位置交互式地图(Google Maps 嵌入)

--- a/components/sections/AboutUs.tsx
+++ b/components/sections/AboutUs.tsx
@@ -4,7 +4,7 @@ import { useTranslations, useLocale } from 'next-intl';
 import { getAuthorById, getAuthorText } from '@/lib/author-data';
 import { useScrollAnimation } from '@/hooks/useScrollAnimation';
 import { TRUSTED_BRANDS } from '@/lib/brand-logos';
-import { FACTORY_INFO } from '@/components/seo/ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * 关于我们区块组件

--- a/components/seo/BlogPostingSchema.tsx
+++ b/components/seo/BlogPostingSchema.tsx
@@ -2,7 +2,7 @@
 
 import type { AuthorProfile } from '@/lib/author-data';
 import { getAuthorText } from '@/lib/author-data';
-import { FACTORY_INFO } from './ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * BlogPostingSchema 组件属性

--- a/components/seo/BreadcrumbSchema.tsx
+++ b/components/seo/BreadcrumbSchema.tsx
@@ -1,6 +1,8 @@
-// 复用同目录常量取站点 URL(与 BlogPostingSchema 一致);
-// 不从 lib/metadata 引入,避免联动 HreflangTags -> i18n 的重依赖链
-import { FACTORY_INFO } from './ManufacturingPlantSchema';
+// 从纯数据模块取站点 URL:本组件是 server 组件,若从 'use client'
+// 模块(如 ManufacturingPlantSchema)导入,拿到的是 client-reference
+// 代理,FACTORY_INFO.url 会变成 undefined(曾致线上输出 "undefined/zh");
+// 也不从 lib/metadata 引入,避免联动 HreflangTags -> i18n 的重依赖链
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * 面包屑条目

--- a/components/seo/FactSheetSchema.tsx
+++ b/components/seo/FactSheetSchema.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FACTORY_INFO } from './ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * Fact Sheet 页面 JSON-LD 的 dateModified(公司事实的最后核实日期)
@@ -30,7 +30,7 @@ interface FactSheetSchemaProps {
  * 识别为公司数据的权威来源。
  *
  * 设计说明:
- * - 与 BlogPostingSchema 同款:'use client' + import 'use client' 模块 FACTORY_INFO
+ * - 与 BlogPostingSchema 同款:'use client' + 复用 lib/factory-info 常量
  * - url 指向具体语言版本:${FACTORY_INFO.url}/${locale}/fact-sheet
  * - dateModified 使用导出常量 FACT_SHEET_DATE_MODIFIED
  *

--- a/components/seo/ManufacturingPlantSchema.tsx
+++ b/components/seo/ManufacturingPlantSchema.tsx
@@ -1,42 +1,9 @@
 'use client';
 
 import { useTranslations, useLocale } from 'next-intl';
-
-/**
- * 工厂基本信息常量
- * 供组件和测试共用
- */
-export const FACTORY_INFO = {
-  name: 'Better Bags Myanmar Company Limited',
-  url: 'https://betterbagsmm.com',
-  logo: 'https://betterbagsmm.com/logo.png',
-  foundingDate: '2003',
-  telephone: '+1-814-880-1463',
-  email: 'jay@betterbagsmm.com',
-  address: {
-    streetAddress: 'Plot No. 48, Myay Taing Block No.24, Ngwe Pin Lai Industrial Zone',
-    addressLocality: 'Yangon',
-    addressCountry: 'MM',
-    postalCode: '11000',
-  },
-  // 坐标取自 Google Business Profile 档案(Ngwe Pin Lai 工业区实地定位,
-  // 2026-07-08 经 Google Maps 核实;旧值 16.871311,96.199379 指向市区东侧,系错误数据)
-  geo: {
-    latitude: 16.9304653,
-    longitude: 96.0619768,
-  },
-  numberOfEmployees: {
-    minValue: 600,
-    maxValue: 700,
-  },
-  credentials: ['ISO 9001', 'OEKO-TEX', 'GRS', 'GOTS'],
-  // 站外权威档案(实体消歧):LinkedIn 公司页 + Google 商家档案。
-  // 搜索引擎与 AI 引擎靠 sameAs 将网站与站外实体对齐(GEO 关键信号)
-  sameAs: [
-    'https://www.linkedin.com/company/better-bags-myanmar/',
-    'https://www.google.com/maps/place/Better+Bags+Myanmar/@16.9304653,96.0619768,17z/',
-  ],
-};
+// 常量住在纯数据模块 lib/factory-info:server 组件(如 BreadcrumbSchema)
+// 也要取值,若定义在本 'use client' 文件内会拿到 client-reference 代理
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * ManufacturingPlantSchema 组件属性

--- a/components/seo/VirtualTourSchema.tsx
+++ b/components/seo/VirtualTourSchema.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FACTORY_INFO } from './ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * VirtualTourSchema 组件属性

--- a/components/seo/index.ts
+++ b/components/seo/index.ts
@@ -4,7 +4,10 @@
  * 提供 Schema.org JSON-LD 结构化数据组件，用于增强 SEO 和搜索结果展示。
  */
 
-export { default as ManufacturingPlantSchema, FACTORY_INFO } from './ManufacturingPlantSchema';
+export { default as ManufacturingPlantSchema } from './ManufacturingPlantSchema';
+// FACTORY_INFO 从纯数据模块 re-export(而非 'use client' 组件文件),
+// 保证 server/client 两侧导入拿到的都是真实对象
+export { FACTORY_INFO } from '@/lib/factory-info';
 export { default as FAQPageSchema } from './FAQPageSchema';
 export type { FAQSection } from './FAQPageSchema';
 export { default as GlossarySchema } from './GlossarySchema';

--- a/lib/factory-info.ts
+++ b/lib/factory-info.ts
@@ -1,0 +1,42 @@
+/**
+ * 工厂基本信息常量(纯数据模块)
+ *
+ * 供 SEO JSON-LD 组件、页面 section 与测试共用。
+ *
+ * 重要:本模块必须保持无 'use client' 指令。BreadcrumbSchema 等
+ * server 组件直接取用这里的值;若常量住在 'use client' 模块里,
+ * server 侧拿到的是 client-reference 代理(FACTORY_INFO.url 为
+ * undefined),曾导致线上 BreadcrumbList 输出 "undefined/zh" 被
+ * Google 判为无效网址(见 tests/seo/server-safe-imports.test.ts)。
+ */
+export const FACTORY_INFO = {
+  name: 'Better Bags Myanmar Company Limited',
+  url: 'https://betterbagsmm.com',
+  logo: 'https://betterbagsmm.com/logo.png',
+  foundingDate: '2003',
+  telephone: '+1-814-880-1463',
+  email: 'jay@betterbagsmm.com',
+  address: {
+    streetAddress: 'Plot No. 48, Myay Taing Block No.24, Ngwe Pin Lai Industrial Zone',
+    addressLocality: 'Yangon',
+    addressCountry: 'MM',
+    postalCode: '11000',
+  },
+  // 坐标取自 Google Business Profile 档案(Ngwe Pin Lai 工业区实地定位,
+  // 2026-07-08 经 Google Maps 核实;旧值 16.871311,96.199379 指向市区东侧,系错误数据)
+  geo: {
+    latitude: 16.9304653,
+    longitude: 96.0619768,
+  },
+  numberOfEmployees: {
+    minValue: 600,
+    maxValue: 700,
+  },
+  credentials: ['ISO 9001', 'OEKO-TEX', 'GRS', 'GOTS'],
+  // 站外权威档案(实体消歧):LinkedIn 公司页 + Google 商家档案。
+  // 搜索引擎与 AI 引擎靠 sameAs 将网站与站外实体对齐(GEO 关键信号)
+  sameAs: [
+    'https://www.linkedin.com/company/better-bags-myanmar/',
+    'https://www.google.com/maps/place/Better+Bags+Myanmar/@16.9304653,96.0619768,17z/',
+  ],
+};

--- a/tests/components/FactoryMapEmbed.test.tsx
+++ b/tests/components/FactoryMapEmbed.test.tsx
@@ -3,7 +3,7 @@ import { render, cleanup } from '@testing-library/react';
 import { NextIntlClientProvider } from 'next-intl';
 import fc from 'fast-check';
 import FactoryMapEmbed from '@/components/content/FactoryMapEmbed';
-import { FACTORY_INFO } from '@/components/seo/ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 import { locales } from '@/i18n';
 
 const messages = {

--- a/tests/final-checkpoint.test.ts
+++ b/tests/final-checkpoint.test.ts
@@ -32,7 +32,7 @@ import {
 import { LANG_COOKIE_NAME } from '@/lib/language-preference';
 
 import { generateHreflangTags } from '@/components/seo/HreflangTags';
-import { FACTORY_INFO } from '@/components/seo/ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 // ---------------------------------------------------------------------------
 // Checkpoint 1: Language System Completeness

--- a/tests/properties/blogposting-schema.test.ts
+++ b/tests/properties/blogposting-schema.test.ts
@@ -3,7 +3,7 @@ import * as fc from 'fast-check';
 import { AUTHORS, getAuthorForPost } from '@/lib/author-data';
 import type { AuthorProfile } from '@/lib/author-data';
 import { BLOG_POSTS } from '@/lib/blog-data';
-import { FACTORY_INFO } from '@/components/seo/ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * BlogPosting Schema 属性测试

--- a/tests/seo/breadcrumb-schema.test.tsx
+++ b/tests/seo/breadcrumb-schema.test.tsx
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema';
-import { FACTORY_INFO } from '@/components/seo/ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 const BASE_URL = FACTORY_INFO.url;
 

--- a/tests/seo/organization-sameas.test.tsx
+++ b/tests/seo/organization-sameas.test.tsx
@@ -22,9 +22,8 @@ vi.mock('next-intl', () => ({
   useLocale: () => 'en',
 }));
 
-import ManufacturingPlantSchema, {
-  FACTORY_INFO,
-} from '@/components/seo/ManufacturingPlantSchema';
+import ManufacturingPlantSchema from '@/components/seo/ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 const LINKEDIN_URL = 'https://www.linkedin.com/company/better-bags-myanmar/';
 const GOOGLE_MAPS_URL =

--- a/tests/seo/rich-results-validation.test.ts
+++ b/tests/seo/rich-results-validation.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
-import { FACTORY_INFO } from '@/components/seo/ManufacturingPlantSchema';
+import { FACTORY_INFO } from '@/lib/factory-info';
 
 /**
  * 模拟 ManufacturingBusiness JSON-LD 生成（与组件行为一致）

--- a/tests/seo/server-safe-imports.test.ts
+++ b/tests/seo/server-safe-imports.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Server 组件导入安全 —— 防止跨 'use client' 边界取常量
+ *
+ * BreadcrumbSchema 无 'use client' 指令,会在 server 页面
+ * (fact-sheet / virtual-factory-tour / blog/[slug])的 RSC 上下文中执行。
+ * 若它从 'use client' 模块导入值,拿到的是 client-reference 代理而非
+ * 真实对象(FACTORY_INFO.url 求值为 undefined),曾导致线上
+ * BreadcrumbList 输出 "item":"undefined/zh",被 GSC 判为
+ * 「字段 id 中的网址无效」。
+ *
+ * 本测试静态检查源码导入关系,锁死该类回归:
+ * - FACTORY_INFO 必须住在无指令的纯数据模块 lib/factory-info.ts
+ * - BreadcrumbSchema 的一切值导入不得解析到 'use client' 模块
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync, statSync } from 'fs';
+import { dirname, resolve } from 'path';
+
+const ROOT = resolve(__dirname, '../..');
+const FACTORY_INFO_MODULE = resolve(ROOT, 'lib/factory-info.ts');
+const BREADCRUMB_MODULE = resolve(ROOT, 'components/seo/BreadcrumbSchema.tsx');
+
+/**
+ * 判断模块源码是否以 'use client' 指令开头
+ */
+function hasUseClientDirective(filePath: string): boolean {
+  const source = readFileSync(filePath, 'utf8');
+  return /^\s*['"]use client['"]/.test(source);
+}
+
+/**
+ * 将 import 说明符解析为项目内源文件绝对路径
+ * (npm 包等项目外模块返回 null,不参与检查)
+ */
+function resolveImportPath(
+  specifier: string,
+  importerPath: string
+): string | null {
+  let base: string;
+  if (specifier.startsWith('@/')) {
+    base = resolve(ROOT, specifier.slice(2));
+  } else if (specifier.startsWith('.')) {
+    base = resolve(dirname(importerPath), specifier);
+  } else {
+    return null;
+  }
+
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}/index.ts`,
+    `${base}/index.tsx`,
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate) && statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * 提取源码中的运行时 import 说明符(忽略纯类型导入 import type)
+ */
+function extractValueImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const importRegex =
+    /import\s+(type\s+)?(?:[\w*{}\s,]+?\s+from\s+)?['"]([^'"]+)['"]/g;
+  let match: RegExpExecArray | null;
+  while ((match = importRegex.exec(source)) !== null) {
+    const isTypeOnly = Boolean(match[1]);
+    if (!isTypeOnly) {
+      specifiers.push(match[2]);
+    }
+  }
+  return specifiers;
+}
+
+describe('Server 组件导入安全(FACTORY_INFO 跨边界回归)', () => {
+  it('lib/factory-info.ts 应存在且为无 use client 指令的纯数据模块', () => {
+    expect(
+      existsSync(FACTORY_INFO_MODULE),
+      'lib/factory-info.ts 不存在:FACTORY_INFO 应抽取到纯数据模块'
+    ).toBe(true);
+    expect(
+      hasUseClientDirective(FACTORY_INFO_MODULE),
+      'lib/factory-info.ts 不得含 use client 指令,否则 server 组件取值仍会拿到代理'
+    ).toBe(false);
+  });
+
+  it('BreadcrumbSchema(server 组件)的值导入不得指向 use client 模块', () => {
+    const source = readFileSync(BREADCRUMB_MODULE, 'utf8');
+    expect(
+      hasUseClientDirective(BREADCRUMB_MODULE),
+      '前提校验:BreadcrumbSchema 应保持 server 组件(无 use client)'
+    ).toBe(false);
+
+    const specifiers = extractValueImportSpecifiers(source);
+    expect(specifiers.length).toBeGreaterThan(0);
+
+    for (const specifier of specifiers) {
+      const target = resolveImportPath(specifier, BREADCRUMB_MODULE);
+      if (!target) continue;
+      expect(
+        hasUseClientDirective(target),
+        `BreadcrumbSchema 导入了 use client 模块 ${specifier}:` +
+          'server 渲染时该模块导出的值是 client-reference 代理,' +
+          '会重现 "undefined/zh" 无效网址问题'
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## 问题

Google Search Console「路径」(Breadcrumbs) 报错:**字段 id 中的网址无效(在 itemListElement.item 中)**,影响 4 个 URL(`/virtual-factory-tour` 的 en/ko/my/zh 版本),首次检测 2026-07-09。

线上实证(curl 生产页面):

```json
{"@type":"ListItem","position":1,"name":"首页","item":"undefined/zh"}
```

## 根因

`BreadcrumbSchema` 是 **server 组件**(无 `'use client'`),却从 `'use client'` 模块 `ManufacturingPlantSchema` 导入常量 `FACTORY_INFO`。RSC 服务端上下文中,跨 client 边界导入的值是 client-reference 代理而非真实对象,`FACTORY_INFO.url` 求值为 `undefined`,拼出 `"undefined/zh"`。

受影响页面(所有在 server 页渲染 BreadcrumbSchema 的路由):
- `/[locale]/virtual-factory-tour`(GSC 已报)
- `/[locale]/fact-sheet`(已实证坏,GSC 尚未重抓——不修受影响数会继续涨)
- `/[locale]/blog/[slug]`

blog 列表页/glossary 页是 client 页面,client 模块图内导入拿到真实值,故未受影响——这也解释了为何 GSC 只报了部分页面。

## 修复

- `FACTORY_INFO` 抽取到纯数据模块 `lib/factory-info.ts`(无 `'use client'`),单一事实源
- 8 处源码引用 + 6 处测试引用改从新模块导入;barrel 从纯模块 re-export
- 新增 `tests/seo/server-safe-imports.test.ts`:静态断言 BreadcrumbSchema 的一切值导入不得解析到 `'use client'` 模块,锁死该类回归(TDD:RED → GREEN)

## 验证

- [x] 新回归测试修复前 RED、修复后 GREEN
- [x] 全量测试 1431 passed / 2 skipped(93 文件)
- [x] `tsc --noEmit` 无错
- [x] 本地 dev 实测三个 server 页,BreadcrumbList 输出完整 URL:
  - `/zh/virtual-factory-tour` → `"item":"https://betterbagsmm.com/zh"`
  - `/zh/fact-sheet` → `"item":"https://betterbagsmm.com/zh"`
  - `/en/blog/factory-tour-one-day-myanmar` → `"item":"https://betterbagsmm.com/en"` + `".../en/blog"`
  - 同页 ManufacturingBusiness / Service schema 输出不变

## 合并后

1. curl 生产三路径确认 `"item":"https://betterbagsmm.com/…"`
2. GSC 该问题页点击**「验证修复」**(可另对 4 个已报 URL 请求编入索引加速重抓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)