### PR TITLE
feat: Yandex Webmaster 站点验证 meta 标签(12 语首页)

### DIFF
--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -33,6 +33,12 @@ export const DEFAULT_OG_IMAGE = '/images/og-image.jpg';
 export const NAVER_SITE_VERIFICATION = '902febe431ab2c1939298f861bafa0fcb52c9cd4';
 
 /**
+ * Yandex Webmaster 站点所有权验证码
+ * 公开信息（随 HTML 明文输出），非机密，无需环境变量
+ */
+export const YANDEX_SITE_VERIFICATION = '24ff1f8e3aa08047';
+
+/**
  * 页面元数据文案（title/description 来自 locales JSON 的 metadata namespace）
  */
 export interface PageMetadata {
@@ -73,9 +79,11 @@ function getOgLocale(locale: Locale): string {
 export function generateHomeMetadata(locale: Locale, meta: PageMetadata): Metadata {
   return {
     ...generateGenericMetadata(locale, meta.title, meta.description, ''),
-    // 站长平台所有权验证（渲染为 <meta name="naver-site-verification" .../>）
-    // 根 layout 使用本函数，全部 locale 首页的 head 均输出该标签
+    // 站长平台所有权验证，根 layout 使用本函数，全部 locale 首页的 head 均输出
+    // Yandex 走 Metadata API 原生字段；Naver 无原生字段，走 other
+    // （分别渲染为 <meta name="yandex-verification"/> 与 <meta name="naver-site-verification"/>）
     verification: {
+      yandex: YANDEX_SITE_VERIFICATION,
       other: {
         'naver-site-verification': NAVER_SITE_VERIFICATION,
       },

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -246,7 +246,7 @@ describe('SEO 元数据配置', () => {
   });
 
   /**
-   * 站长平台验证标签（Naver Search Advisor 站点所有权验证）
+   * 站长平台验证标签（Naver Search Advisor / Yandex Webmaster 站点所有权验证）
    */
   describe('站长平台验证标签', () => {
     it.each(locales)('%s 首页元数据应包含 naver-site-verification 验证码', (locale) => {
@@ -256,6 +256,12 @@ describe('SEO 元数据配置', () => {
       expect(other?.['naver-site-verification']).toBe(
         '902febe431ab2c1939298f861bafa0fcb52c9cd4'
       );
+    });
+
+    it.each(locales)('%s 首页元数据应包含 yandex-verification 验证码', (locale) => {
+      const metadata = generateHomeMetadata(locale, allMetadata[locale].home);
+
+      expect(metadata.verification?.yandex).toBe('24ff1f8e3aa08047');
     });
   });
 


### PR DESCRIPTION
## 概要

Yandex Webmaster 站点所有权验证:全部 12 个 locale 首页 `<head>` 输出 `<meta name="yandex-verification" content="24ff1f8e3aa08047"/>`。照抄 Naver 验证(PR #20)的模式;Yandex 有 Next.js Metadata API 原生 `verification.yandex` 字段,直接使用(Naver 无原生字段,继续走 `verification.other`)。

与刚接入的 IndexNow(PR #22)形成闭环:IndexNow 已在向 Yandex 推送 URL,验证所有权后可在 Yandex Webmaster 看到收录与推送数据(俄语市场,站点有 ru locale)。

## 变更

- `lib/metadata.ts` — `YANDEX_SITE_VERIFICATION` 常量 + `generateHomeMetadata` 的 `verification.yandex`
- `tests/metadata.test.ts` — 12 语言参数化断言(TDD 先行)

无需改动:`lib/bot-detector.ts` 已有 `/yandexbot/i` 且测试已覆盖;robots.ts 不涉及。

## 测试

全量 **1473 passed | 2 skipped**(新增 12)。

## 合并部署后

1. `curl -s https://betterbagsmm.com/en | grep yandex-verification` 应输出验证 meta
2. 用户在 Yandex Webmaster 点 Verify 完成验证
3. 顺带观察:本次部署触发的 IndexNow run 应返回 200(key 已完成首次验证)

🤖 Generated with [Claude Code](https://claude.com/claude-code)