### PR TITLE
fix: 修复 GSC 索引问题(www 归一/hreflang 冲突/旧 slug 308/sitemap lastmod)

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -10,9 +10,15 @@
  */
 
 import { MetadataRoute } from 'next';
-import { getAllBlogPosts } from '@/lib/blog-data';
+import { getAllBlogPosts, type BlogPost } from '@/lib/blog-data';
 import { BASE_URL } from '@/lib/metadata';
 import { locales, localeConfig, defaultLocale } from '@/i18n';
+import {
+  HOME_DATE_MODIFIED,
+  GLOSSARY_DATE_MODIFIED,
+  FACT_SHEET_DATE_MODIFIED,
+  VIRTUAL_TOUR_DATE_MODIFIED,
+} from '@/lib/content-dates';
 
 /**
  * Generate language alternates for a given path across all locales
@@ -48,30 +54,41 @@ function generateLocalizedEntries(
   }));
 }
 
+/**
+ * Real last-modified date of a blog post (falls back to publish date)
+ */
+function postLastModified(post: BlogPost): Date {
+  return new Date(post.dateModified ?? post.date);
+}
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const currentDate = new Date();
+  // lastmod uses real content dates from lib/content-dates instead of
+  // new Date(): a build-time timestamp would mark every page as "changed"
+  // on each deployment and erode crawl trust.
 
-  // Homepage (all 10 languages)
-  const homepages = generateLocalizedEntries('', currentDate, 'daily', 1.0);
+  // Homepage (all locales)
+  const homepages = generateLocalizedEntries('', new Date(HOME_DATE_MODIFIED), 'daily', 1.0);
 
-  // Glossary page (all 10 languages)
-  const glossaryPages = generateLocalizedEntries('/glossary', currentDate, 'weekly', 0.8);
+  // Glossary page (all locales)
+  const glossaryPages = generateLocalizedEntries('/glossary', new Date(GLOSSARY_DATE_MODIFIED), 'weekly', 0.8);
 
   // Fact Sheet page (GEO / AI-search optimized, all locales)
-  const factSheetPages = generateLocalizedEntries('/fact-sheet', currentDate, 'monthly', 0.8);
+  const factSheetPages = generateLocalizedEntries('/fact-sheet', new Date(FACT_SHEET_DATE_MODIFIED), 'monthly', 0.8);
 
   // Virtual Factory Tour booking page (all locales)
-  const virtualTourPages = generateLocalizedEntries('/virtual-factory-tour', currentDate, 'monthly', 0.8);
+  const virtualTourPages = generateLocalizedEntries('/virtual-factory-tour', new Date(VIRTUAL_TOUR_DATE_MODIFIED), 'monthly', 0.8);
 
-  // Blog list page (all 10 languages)
-  const blogPages = generateLocalizedEntries('/blog', currentDate, 'daily', 0.9);
-
-  // Blog post pages (all 10 languages per post)
+  // Blog list page (all locales): newest modification date across posts
   const posts = getAllBlogPosts();
-  const blogPosts: MetadataRoute.Sitemap = posts.flatMap((post) => {
-    const postDate = new Date(post.date);
-    return generateLocalizedEntries(`/blog/${post.slug}`, postDate, 'weekly', 0.8);
-  });
+  const blogListDate = posts.length
+    ? new Date(Math.max(...posts.map((post) => postLastModified(post).getTime())))
+    : new Date(HOME_DATE_MODIFIED);
+  const blogPages = generateLocalizedEntries('/blog', blogListDate, 'daily', 0.9);
+
+  // Blog post pages (all locales per post)
+  const blogPosts: MetadataRoute.Sitemap = posts.flatMap((post) =>
+    generateLocalizedEntries(`/blog/${post.slug}`, postLastModified(post), 'weekly', 0.8)
+  );
 
   return [...homepages, ...glossaryPages, ...factSheetPages, ...virtualTourPages, ...blogPages, ...blogPosts];
 }

--- a/components/seo/FactSheetSchema.tsx
+++ b/components/seo/FactSheetSchema.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { FACTORY_INFO } from '@/lib/factory-info';
+import { FACT_SHEET_DATE_MODIFIED } from '@/lib/content-dates';
 
 /**
  * Fact Sheet 页面 JSON-LD 的 dateModified(公司事实的最后核实日期)
  *
- * 单独导出为常量,便于测试断言与后续统一维护。
+ * 常量本体住在 lib/content-dates(纯模块,app/sitemap.ts 共用);
+ * 此处 re-export 保持 components/seo 既有导入路径兼容。
  */
-export const FACT_SHEET_DATE_MODIFIED = '2026-07-01';
+export { FACT_SHEET_DATE_MODIFIED };
 
 /**
  * FactSheetSchema 组件属性

--- a/lib/content-dates.ts
+++ b/lib/content-dates.ts
@@ -1,0 +1,26 @@
+/**
+ * 静态页面内容的真实最后修改日期(YYYY-MM-DD)
+ *
+ * 用途:app/sitemap.ts 的 lastmod 与页面 JSON-LD 的 dateModified 共用,
+ * 取代 new Date() —— 后者使每次部署全站 lastmod 刷新为构建时刻,
+ * 与内容是否真实变更无关,损耗 Google 抓取信任。
+ *
+ * 必须保持纯数据模块(无 'use client'、无组件依赖),server 侧
+ * sitemap 才能安全导入;跨 'use client' 边界取值曾导致
+ * BreadcrumbList 输出 "undefined/zh" 线上事故(见 tests/seo/server-safe-imports.test.ts)。
+ *
+ * 维护规则:页面内容(文案/区块/数据)有实质修改时,手工更新对应常量。
+ * 初始值依据 git log 中最后一次实质内容提交:
+ * - HOME:         2026-07-08 Contact 区 Google Maps 嵌入 + WhatsApp 链接修复
+ * - GLOSSARY:     2026-07-08 页面增补 dateModified/Breadcrumb(词条数据本体 2026-02-04)
+ * - FACT_SHEET:   2026-07-01 公司事实最后核实日(原 FactSheetSchema 常量迁入)
+ * - VIRTUAL_TOUR: 2026-07-08 落地页上线及链接修复
+ */
+
+export const HOME_DATE_MODIFIED = '2026-07-08';
+
+export const GLOSSARY_DATE_MODIFIED = '2026-07-08';
+
+export const FACT_SHEET_DATE_MODIFIED = '2026-07-01';
+
+export const VIRTUAL_TOUR_DATE_MODIFIED = '2026-07-08';

--- a/lib/redirects.ts
+++ b/lib/redirects.ts
@@ -1,0 +1,68 @@
+/**
+ * next.config redirects 规则(纯数据模块,可单测)
+ *
+ * 执行时机:先于 middleware(headers -> redirects -> middleware -> 文件系统),
+ * 因此 www 归一与旧 slug 308 均不受 geo/locale 中间件影响,且覆盖
+ * middleware matcher 排除的带点路径(sitemap.xml / robots.txt / 静态资源)。
+ *
+ * 注意:本模块被 next.config.ts 以相对路径引用,不能依赖 '@/' 别名,
+ * 也不能引入任何 'use client' 模块。
+ */
+import type { NextConfig } from 'next';
+import { locales } from '../i18n';
+
+type RedirectRule = Awaited<ReturnType<NonNullable<NextConfig['redirects']>>>[number];
+
+/** 生产 apex 域名(与 lib/metadata 的 BASE_URL 默认值一致,有防漂移测试) */
+export const APEX_ORIGIN = 'https://betterbagsmm.com';
+
+/**
+ * 2026-05-28 commit 344d160 博客改版删除的旧 slug(曾被收录约 4.5 个月),
+ * 统一 308 到对应语言的 /blog 列表:回收外链权益、消灭 GSC「未找到 404」。
+ * 不做旧文 -> 新文的主题映射,不相关映射会被 Google 判 soft-404。
+ */
+export const REMOVED_BLOG_SLUGS = [
+  'custom-backpack-guide-2024',
+  'sustainable-materials-backpacks',
+  'oem-vs-odm-differences',
+  'quality-control-process',
+  'backpack-trends-2024',
+  'choosing-right-backpack-manufacturer',
+] as const;
+
+/** path-to-regexp 参数正则:连字符为字面量无需转义(与 Next 内置 i18n 同款拼法) */
+const LOCALE_PATTERN = locales.join('|');
+const REMOVED_SLUG_PATTERN = REMOVED_BLOG_SLUGS.join('|');
+
+/**
+ * www -> apex 308 永久重定向
+ * - has host 按正则解释,点号转义做精确匹配
+ * - localhost / *.vercel.app preview 的 host 不满足条件,天然不受影响
+ */
+export const wwwToApexRedirect: RedirectRule = {
+  source: '/:path*',
+  has: [{ type: 'host', value: 'www\\.betterbagsmm\\.com' }],
+  destination: `${APEX_ORIGIN}/:path*`,
+  permanent: true,
+};
+
+export const removedBlogSlugRedirects: RedirectRule[] = [
+  // 带 locale 前缀 -> 同语言 blog 列表(:slug 未用于 destination,
+  // Next redirects 的 appendParamsToQuery=false,不会泄漏为 query 参数)
+  {
+    source: `/:locale(${LOCALE_PATTERN})/blog/:slug(${REMOVED_SLUG_PATTERN})`,
+    destination: '/:locale/blog',
+    permanent: true,
+  },
+  // 无前缀变体 -> 单跳直达 /en/blog(与 x-default 一致,避免 308+302 两跳链)
+  {
+    source: `/blog/:slug(${REMOVED_SLUG_PATTERN})`,
+    destination: '/en/blog',
+    permanent: true,
+  },
+];
+
+/** next.config redirects() 的唯一入口;www 规则放最前(先归一 host 再谈路径) */
+export function buildRedirects(): RedirectRule[] {
+  return [wwwToApexRedirect, ...removedBlogSlugRedirects];
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,7 +24,8 @@ import {
  * 5. Default locale (en)
  *
  * Special handling:
- * - Bots: Use botMiddleware (no locale detection, no redirect)
+ * - Bots: no geo/cookie detection; unprefixed paths 308 to /en,
+ *   prefixed paths served via botMiddleware
  */
 
 /**
@@ -36,6 +37,11 @@ const intlMiddleware = createMiddleware({
   localePrefix: 'always',
   // Disable auto detection - we handle priority manually
   localeDetection: false,
+  // No Link-header hreflang: its codes (zh/zh-tw) conflict with the
+  // zh-Hans/zh-Hant set in HTML + sitemap, its x-default points at
+  // redirecting unprefixed paths, and it follows the request host (www).
+  // hreflang source of truth = HTML head + sitemap.
+  alternateLinks: false,
 });
 
 /**
@@ -51,6 +57,7 @@ const botMiddleware = createMiddleware({
   defaultLocale,
   localePrefix: 'always',
   localeDetection: false,
+  alternateLinks: false,
 });
 
 /**
@@ -83,6 +90,15 @@ export default function middleware(request: NextRequest): NextResponse {
 
   // 1. Bot detection: use botMiddleware (no locale detection)
   if (detectBot(userAgent)) {
+    // Unprefixed paths are permanently at /en for crawlers (matches
+    // x-default), so send 308 instead of next-intl's default 307 --
+    // a temporary redirect keeps Google from consolidating the URLs.
+    if (!getLocaleFromPath(request.nextUrl.pathname)) {
+      return NextResponse.redirect(
+        buildRedirectUrl(request.url, defaultLocale),
+        308
+      );
+    }
     return botMiddleware(request);
   }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,17 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from 'next-intl/plugin';
+import { buildRedirects } from './lib/redirects';
 
 const withNextIntl = createNextIntlPlugin('./i18n.ts');
 
 const nextConfig: NextConfig = {
   // 解决多 lockfile 警告：明确指定项目根目录为工作区
   outputFileTracingRoot: __dirname,
+
+  // www 归一 + 旧博客 slug 308(规则与测试见 lib/redirects.ts)
+  async redirects() {
+    return buildRedirects();
+  },
 
   /**
    * 性能优化配置 - 需求 15.4, 15.5

--- a/tests/seo/content-dates.test.ts
+++ b/tests/seo/content-dates.test.ts
@@ -1,0 +1,49 @@
+/**
+ * lib/content-dates —— 静态页面内容日期常量验证
+ *
+ * 验证:
+ * - 四个日期常量均为 YYYY-MM-DD 格式、可解析、不在未来
+ * - components/seo 的 FACT_SHEET_DATE_MODIFIED re-export 与纯模块同值
+ *   (常量本体必须住在 lib/ 纯模块,server 侧 sitemap 才能安全导入;
+ *   跨 'use client' 边界取值是 server-safe-imports.test.ts 记载的事故模式)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  HOME_DATE_MODIFIED,
+  GLOSSARY_DATE_MODIFIED,
+  FACT_SHEET_DATE_MODIFIED,
+  VIRTUAL_TOUR_DATE_MODIFIED,
+} from '@/lib/content-dates';
+import { FACT_SHEET_DATE_MODIFIED as REEXPORTED_FACT_SHEET_DATE } from '@/components/seo';
+
+const ALL_DATE_CONSTANTS: Record<string, string> = {
+  HOME_DATE_MODIFIED,
+  GLOSSARY_DATE_MODIFIED,
+  FACT_SHEET_DATE_MODIFIED,
+  VIRTUAL_TOUR_DATE_MODIFIED,
+};
+
+describe('lib/content-dates 日期常量', () => {
+  it('每个常量均为 YYYY-MM-DD 格式', () => {
+    for (const [name, value] of Object.entries(ALL_DATE_CONSTANTS)) {
+      expect(value, `${name} 格式错误`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it('每个常量均可解析为合法日期且不在未来', () => {
+    for (const [name, value] of Object.entries(ALL_DATE_CONSTANTS)) {
+      const parsed = new Date(value);
+      expect(Number.isNaN(parsed.getTime()), `${name} 不可解析`).toBe(false);
+      expect(parsed.getTime(), `${name} 是未来日期`).toBeLessThanOrEqual(Date.now());
+    }
+  });
+
+  it('components/seo re-export 的 FACT_SHEET_DATE_MODIFIED 与纯模块同值', () => {
+    expect(REEXPORTED_FACT_SHEET_DATE).toBe(FACT_SHEET_DATE_MODIFIED);
+  });
+
+  it('FACT_SHEET_DATE_MODIFIED 保持既有值 2026-07-01(公司事实最后核实日)', () => {
+    expect(FACT_SHEET_DATE_MODIFIED).toBe('2026-07-01');
+  });
+});

--- a/tests/seo/middleware-link-header.test.ts
+++ b/tests/seo/middleware-link-header.test.ts
@@ -1,0 +1,95 @@
+/**
+ * middleware —— hreflang Link header 关闭与爬虫重定向语义验证
+ *
+ * 背景(GSC「网页会自动重定向」/「重复网页」根因):
+ * - next-intl 默认在每个响应输出 HTTP Link header 版 hreflang,其语言代码
+ *   用路由前缀(zh/zh-tw),与 HTML head 及 sitemap 的 zh-Hans/zh-Hant 冲突;
+ *   x-default 指向会重定向的无前缀路径;且跟随请求 host(www 域下整套变 www)。
+ *   关闭后 hreflang 唯一信源 = HTML + sitemap(两者一致)。
+ * - 爬虫访问无前缀路径此前为 307 临时重定向,Google 不合并权重;
+ *   localePrefix:'always' 下无前缀 -> /en 对爬虫是永久事实,应为 308。
+ * - 普通用户无前缀路径保持 302:目标因 cookie/geo 而异,必须临时。
+ */
+
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { NextRequest } from 'next/server';
+import middleware from '@/middleware';
+import { locales, type Locale } from '@/i18n';
+
+const GOOGLEBOT_UA =
+  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+const CHROME_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+const PAGE_PATHS = ['', '/blog', '/fact-sheet', '/glossary', '/virtual-factory-tour'];
+
+function request(path: string, userAgent: string): NextRequest {
+  return new NextRequest(`https://betterbagsmm.com${path}`, {
+    headers: { 'user-agent': userAgent },
+  });
+}
+
+describe('middleware 不再输出 hreflang Link header', () => {
+  it('属性:任意 locale × 任意页面路径,爬虫请求带前缀 URL 响应无 Link header', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...locales),
+        fc.constantFrom(...PAGE_PATHS),
+        (locale: Locale, path: string) => {
+          const response = middleware(request(`/${locale}${path}`, GOOGLEBOT_UA));
+          expect(response.headers.get('link')).toBeNull();
+        }
+      ),
+      { numRuns: 60 }
+    );
+  });
+
+  it('属性:任意 locale × 任意页面路径,普通用户请求带前缀 URL 响应无 Link header', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...locales),
+        fc.constantFrom(...PAGE_PATHS),
+        (locale: Locale, path: string) => {
+          const response = middleware(request(`/${locale}${path}`, CHROME_UA));
+          expect(response.headers.get('link')).toBeNull();
+        }
+      ),
+      { numRuns: 60 }
+    );
+  });
+});
+
+describe('爬虫无前缀路径 308 永久重定向', () => {
+  it('属性:任意无前缀页面路径,爬虫请求 308 到 /en 前缀版', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...PAGE_PATHS), (path: string) => {
+        const response = middleware(request(path || '/', GOOGLEBOT_UA));
+        expect(response.status).toBe(308);
+        expect(response.headers.get('location')).toBe(
+          `https://betterbagsmm.com/en${path}`
+        );
+      }),
+      { numRuns: 20 }
+    );
+  });
+
+  it('爬虫请求根路径 / 应 308 到 /en', () => {
+    const response = middleware(request('/', GOOGLEBOT_UA));
+    expect(response.status).toBe(308);
+    expect(response.headers.get('location')).toBe('https://betterbagsmm.com/en');
+  });
+});
+
+describe('普通用户重定向语义保持不变(回归保护)', () => {
+  it('无 cookie 无 geo 的用户请求 / 应 302 临时重定向(目标因人而异)', () => {
+    const response = middleware(request('/', CHROME_UA));
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('https://betterbagsmm.com/en');
+  });
+
+  it('用户请求带前缀 URL 正常放行(非重定向)', () => {
+    const response = middleware(request('/zh/blog', CHROME_UA));
+    expect(response.status).toBeLessThan(300);
+  });
+});

--- a/tests/seo/redirects-config.test.ts
+++ b/tests/seo/redirects-config.test.ts
@@ -1,0 +1,109 @@
+/**
+ * lib/redirects —— next.config redirects 规则验证
+ *
+ * 背景(GSC「重复网页」/「未找到 404」根因):
+ * - www 子域整站 200 未归一到 apex,形成重复站点(实测 www.betterbagsmm.com/en 返回 200)
+ * - 2026-05-28 博客改版删除 6 个旧 slug,曾被收录 4.5 个月,无 301 直接 404
+ *
+ * 验证:
+ * - www 规则形状:has host 精确匹配、destination 指向 apex、permanent(308)
+ * - APEX_ORIGIN 与 lib/metadata BASE_URL 防漂移
+ * - 旧 slug 恰 6 个,与现存文章 slug 无交集(防未来误伤)
+ * - 用 Next 真实匹配器(getPathMatch)锁死路由匹配行为:
+ *   任意 locale × 旧 slug 命中且 locale 捕获完整(zh-tw 不被 zh 截断);
+ *   现存文章 slug 不命中;无前缀变体单跳 /en/blog
+ */
+
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+// Next 内部 API(15.x 路径稳定);若升级 Next 后挪位,退化为字符串断言即可
+import { getPathMatch } from 'next/dist/shared/lib/router/utils/path-match';
+import {
+  APEX_ORIGIN,
+  REMOVED_BLOG_SLUGS,
+  wwwToApexRedirect,
+  removedBlogSlugRedirects,
+  buildRedirects,
+} from '@/lib/redirects';
+import { BASE_URL } from '@/lib/metadata';
+import { getAllBlogPosts } from '@/lib/blog-data';
+import { locales, type Locale } from '@/i18n';
+
+describe('www -> apex 归一规则', () => {
+  it('buildRedirects 首条为 www 规则(先归一 host 再谈路径)', () => {
+    expect(buildRedirects()[0]).toBe(wwwToApexRedirect);
+  });
+
+  it('www 规则形状:has host 精确匹配、destination 指向 apex、永久重定向', () => {
+    expect(wwwToApexRedirect.source).toBe('/:path*');
+    expect(wwwToApexRedirect.has).toEqual([
+      { type: 'host', value: 'www\\.betterbagsmm\\.com' },
+    ]);
+    expect(wwwToApexRedirect.destination).toBe(`${APEX_ORIGIN}/:path*`);
+    expect(wwwToApexRedirect.permanent).toBe(true);
+  });
+
+  it('APEX_ORIGIN 与 lib/metadata 的 BASE_URL 一致(防漂移)', () => {
+    expect(APEX_ORIGIN).toBe(BASE_URL);
+  });
+});
+
+describe('旧博客 slug 重定向规则', () => {
+  const [prefixedRule, unprefixedRule] = removedBlogSlugRedirects;
+
+  it('恰 6 个旧 slug,且与现存文章 slug 无交集', () => {
+    expect(REMOVED_BLOG_SLUGS.length).toBe(6);
+    const currentSlugs = new Set(getAllBlogPosts().map((post) => post.slug));
+    for (const slug of REMOVED_BLOG_SLUGS) {
+      expect(currentSlugs.has(slug), `${slug} 与现存文章冲突`).toBe(false);
+    }
+  });
+
+  it('全部规则均为永久重定向', () => {
+    for (const rule of buildRedirects()) {
+      expect(rule.permanent).toBe(true);
+    }
+  });
+
+  it('属性:任意 locale × 旧 slug 命中带前缀规则,locale 捕获完整(zh-tw 不被 zh 截断)', () => {
+    const matcher = getPathMatch(prefixedRule.source);
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...locales),
+        fc.constantFrom(...REMOVED_BLOG_SLUGS),
+        (locale: Locale, slug: string) => {
+          const params = matcher(`/${locale}/blog/${slug}`);
+          expect(params).not.toBe(false);
+          expect((params as Record<string, string>).locale).toBe(locale);
+          expect((params as Record<string, string>).slug).toBe(slug);
+        }
+      ),
+      { numRuns: 72 }
+    );
+    expect(prefixedRule.destination).toBe('/:locale/blog');
+  });
+
+  it('属性:现存文章 slug 不命中任何旧 slug 规则', () => {
+    const prefixedMatcher = getPathMatch(prefixedRule.source);
+    const unprefixedMatcher = getPathMatch(unprefixedRule.source);
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...locales),
+        fc.constantFrom(...getAllBlogPosts().map((post) => post.slug)),
+        (locale: Locale, slug: string) => {
+          expect(prefixedMatcher(`/${locale}/blog/${slug}`)).toBe(false);
+          expect(unprefixedMatcher(`/blog/${slug}`)).toBe(false);
+        }
+      ),
+      { numRuns: 36 }
+    );
+  });
+
+  it('无前缀变体命中并单跳 /en/blog(避免 308+302 两跳链)', () => {
+    const matcher = getPathMatch(unprefixedRule.source);
+    for (const slug of REMOVED_BLOG_SLUGS) {
+      expect(matcher(`/blog/${slug}`)).not.toBe(false);
+    }
+    expect(unprefixedRule.destination).toBe('/en/blog');
+  });
+});

--- a/tests/seo/sitemap-lastmod.test.ts
+++ b/tests/seo/sitemap-lastmod.test.ts
@@ -1,0 +1,115 @@
+/**
+ * sitemap.xml —— lastModified 真实化验证
+ *
+ * 背景:此前 5 类静态页面的 lastModified 用 new Date(),每次部署全站
+ * lastmod 集体刷新为构建时刻,与内容是否真实变更无关,损耗 Google 抓取信任
+ * (GSC「已抓取-尚未编入索引」的诱因之一)。
+ *
+ * 验证:
+ * - 确定性:系统时间移动 30 天,两次 sitemap() 输出深等(锁死 new Date() 回归)
+ * - 各静态页面条目 lastModified 等于 lib/content-dates 对应常量
+ * - 博客文章条目 = post.dateModified ?? post.date
+ * - 博客列表条目 = 全部文章的最新修改日
+ * - 守卫:所有条目日期合法且不在未来
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import sitemap from '@/app/sitemap';
+import { BASE_URL } from '@/lib/metadata';
+import { getAllBlogPosts } from '@/lib/blog-data';
+import {
+  HOME_DATE_MODIFIED,
+  GLOSSARY_DATE_MODIFIED,
+  FACT_SHEET_DATE_MODIFIED,
+  VIRTUAL_TOUR_DATE_MODIFIED,
+} from '@/lib/content-dates';
+import { locales } from '@/i18n';
+
+function entriesEndingWith(suffix: string) {
+  return sitemap().filter((entry) => entry.url.endsWith(suffix));
+}
+
+function toTime(lastModified: string | Date | undefined): number {
+  expect(lastModified).toBeDefined();
+  return new Date(lastModified as string | Date).getTime();
+}
+
+describe('sitemap lastModified 确定性', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('系统时间移动 30 天,两次 sitemap() 输出应完全一致', () => {
+    vi.useFakeTimers();
+
+    vi.setSystemTime(new Date('2026-07-21T00:00:00.000Z'));
+    const first = sitemap();
+
+    vi.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+    const second = sitemap();
+
+    expect(second).toEqual(first);
+  });
+});
+
+describe('sitemap 各类条目 lastModified 取值', () => {
+  it('首页条目等于 HOME_DATE_MODIFIED', () => {
+    const homepages = sitemap().filter((entry) =>
+      locales.some((locale) => entry.url === `${BASE_URL}/${locale}`)
+    );
+    expect(homepages.length).toBe(locales.length);
+    for (const entry of homepages) {
+      expect(toTime(entry.lastModified)).toBe(new Date(HOME_DATE_MODIFIED).getTime());
+    }
+  });
+
+  it('glossary 条目等于 GLOSSARY_DATE_MODIFIED', () => {
+    for (const entry of entriesEndingWith('/glossary')) {
+      expect(toTime(entry.lastModified)).toBe(new Date(GLOSSARY_DATE_MODIFIED).getTime());
+    }
+  });
+
+  it('fact-sheet 条目等于 FACT_SHEET_DATE_MODIFIED', () => {
+    for (const entry of entriesEndingWith('/fact-sheet')) {
+      expect(toTime(entry.lastModified)).toBe(new Date(FACT_SHEET_DATE_MODIFIED).getTime());
+    }
+  });
+
+  it('virtual-factory-tour 条目等于 VIRTUAL_TOUR_DATE_MODIFIED', () => {
+    for (const entry of entriesEndingWith('/virtual-factory-tour')) {
+      expect(toTime(entry.lastModified)).toBe(new Date(VIRTUAL_TOUR_DATE_MODIFIED).getTime());
+    }
+  });
+
+  it('博客文章条目等于 post.dateModified ?? post.date', () => {
+    for (const post of getAllBlogPosts()) {
+      const expected = new Date(post.dateModified ?? post.date).getTime();
+      const postEntries = entriesEndingWith(`/blog/${post.slug}`);
+      expect(postEntries.length).toBe(locales.length);
+      for (const entry of postEntries) {
+        expect(toTime(entry.lastModified)).toBe(expected);
+      }
+    }
+  });
+
+  it('博客列表条目等于全部文章的最新修改日', () => {
+    const expected = Math.max(
+      ...getAllBlogPosts().map((post) =>
+        new Date(post.dateModified ?? post.date).getTime()
+      )
+    );
+    const blogListEntries = entriesEndingWith('/blog');
+    expect(blogListEntries.length).toBe(locales.length);
+    for (const entry of blogListEntries) {
+      expect(toTime(entry.lastModified)).toBe(expected);
+    }
+  });
+
+  it('守卫:所有条目日期合法且不在未来', () => {
+    for (const entry of sitemap()) {
+      const time = toTime(entry.lastModified);
+      expect(Number.isNaN(time), `${entry.url} 日期非法`).toBe(false);
+      expect(time, `${entry.url} 是未来日期`).toBeLessThanOrEqual(Date.now());
+    }
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -41,6 +41,14 @@ export default defineConfig({
 
     // 属性测试（fast-check asyncProperty）需要更长的超时时间
     testTimeout: 30000,
+
+    // next-intl 的 ESM 产物含无扩展名的 next/server 裸导入,
+    // 须经 vite 内联转换才能在测试中导入 middleware(见 middleware-link-header.test.ts)
+    server: {
+      deps: {
+        inline: ['next-intl'],
+      },
+    },
   },
 
   resolve: {


### PR DESCRIPTION
## 背景

GSC「网页索引编制」报告 6 类未编入索引问题(共 61 条)。经代码探索 + 线上实测逐项定位根因,本 PR 修复其中代码可解的全部 4 项。

## 诊断与修复对照

| GSC 分类 | 根因 | 本 PR 处置 |
|---|---|---|
| 未找到 404 (1) | 2026-05-28 博客改版删除 6 个旧 slug,曾被收录 4.5 个月,无 301 | 308 到对应语言 /blog 列表(无前缀变体单跳 /en/blog) |
| 网页会自动重定向 (3) | 无前缀 URL 对爬虫只有 307 临时重定向;middleware Link header 的 x-default 还指向这些会重定向的路径 | 爬虫无前缀路径 307→308;关闭 Link header |
| 重复网页 (1+3) | www 子域整站 200 未归一;Link header hreflang 与 HTML/sitemap 冲突(zh/zh-tw vs zh-Hans/zh-Hant、www 域下整套跟随 host) | next.config redirects: www→apex 308(先于 middleware 执行,覆盖 sitemap.xml 等静态路径);alternateLinks:false |
| 已发现/已抓取-尚未编入索引 (47+6) | 新站+12 语正常现象;sitemap lastModified 用 new Date() 每次部署全站刷新,损耗抓取信任 | lastmod 真实化:lib/content-dates 常量 + post.dateModified |

HTML canonical/hreflang 与 sitemap 本身正确一致,未改动。用户侧 302 语义保持不变(目标因 cookie/geo 而异,必须临时)。

## 改动

- **lib/redirects.ts(新)**: www→apex 308 + 6 旧 slug 308,纯数据模块可单测;next.config.ts 接线
- **middleware.ts**: 两个 next-intl 实例 `alternateLinks: false`;爬虫无前缀路径 308(复用 geo-router 的 buildRedirectUrl)
- **lib/content-dates.ts(新)**: 4 个页面真实修改日期常量;FACT_SHEET_DATE_MODIFIED 从 'use client' 组件迁入纯模块(re-export 保持兼容,避免 server 跨边界取值事故模式)
- **app/sitemap.ts**: 删 new Date();博客文章取 dateModified ?? date;blog 列表取全文章最新修改日
- **vitest.config.mts**: inline next-intl(middleware 集成测试所需)

## 测试

- 新增 4 个测试文件 22 用例(TDD 先行):redirects 规则用 Next 真实匹配器 getPathMatch 锁死 zh-tw 捕获;middleware 用 NextRequest 集成测试断言无 Link header/308/302;sitemap 用 fake timers 锁死 new Date 回归
- 全量 `npm test`:**1499 passed, 2 skipped**(既有);`npm run build` 成功(BUILD_ID 已验证)
- 本地 `next start` curl 矩阵全过:www(含 /sitemap.xml)308→apex、旧 slug 308、现存文章 200、爬虫 / 308→/en、用户 / 302 不变、响应无 hreflang Link header、sitemap 出现 3 组真实 lastmod

## 部署后操作(代码之外)

1. 生产域名复跑 curl 矩阵
2. GSC:「未找到(404)」「网页会自动重定向」点「验证修复」;主语种页「请求编入索引」;跑一次 `npm run indexnow`
3. (可选双保险)Vercel Domains 把 www 设为 Redirect 308
4. 「已发现-尚未编入索引 47」属新站正常现象,2-4 周后复查收敛

🤖 Generated with [Claude Code](https://claude.com/claude-code)