### PR TITLE
perf: logo Image 加 sizes 消除全站 3840px 超大图预加载

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -59,6 +59,7 @@ export default function Footer() {
                 alt="Better Bags Myanmar"
                 width={2481}
                 height={1038}
+                sizes="96px"
                 className="h-10 w-auto"
               />
             </span>

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -72,6 +72,7 @@ export default function Navbar() {
                 alt="Better Bags Myanmar"
                 width={2481}
                 height={1038}
+                sizes="96px"
                 priority
                 className="h-9 w-auto md:h-10 transition-transform group-hover:scale-105"
               />

--- a/tests/components/logo-image-sizes.test.tsx
+++ b/tests/components/logo-image-sizes.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * logo Image sizes 测试
+ *
+ * 背景(GSC /ja 资源报告排查发现):Navbar/Footer 的 logo Image 写了
+ * width={2481} 但没写 sizes,Next 按内在宽度从 deviceSizes 挑档,
+ * 1x/2x 全落到 w=3840 超大图;Navbar 版还带 priority,等于全站每页
+ * 预加载一张 3840px 的图,而 logo 实际显示仅约 96px 宽。
+ * 修复:两处 Image 加 sizes="96px",浏览器改取 128/256 小档。
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import fs from 'fs';
+import path from 'path';
+import Navbar from '@/components/layout/Navbar';
+import Footer from '@/components/layout/Footer';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/en',
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useNavigation', () => ({
+  useScrollState: () => false,
+  useActiveSection: () => 'banner',
+  useSmoothScroll: () => vi.fn(),
+  useMobileMenu: () => ({
+    isOpen: false,
+    toggle: vi.fn(),
+    close: vi.fn(),
+    menuRef: { current: null },
+  }),
+}));
+
+const messages = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), 'locales', 'en.json'), 'utf-8')
+);
+
+function renderWithIntl(ui: React.ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+function expectLogoUsesSmallSizes(container: HTMLElement, where: string) {
+  const logo = container.querySelector('img[alt="Better Bags Myanmar"]');
+  expect(logo, `${where}: 找不到 logo img`).not.toBeNull();
+
+  // 纯 px 的 sizes 会让 next/image 输出全量 srcset 候选(含 3840w),
+  // 但浏览器/爬虫按 sizes 属性选档:96px × DPR≤3 只会命中 128/256/384,
+  // 3840 永远不被选中;priority 预加载同理经 imagesizes 走小档。
+  // 因此断言锚定在 sizes 属性 + 小档候选存在,而非 3840 缺席。
+  expect(logo!.getAttribute('sizes'), `${where}: logo 缺少 sizes 属性`).toBe('96px');
+
+  const srcset = logo!.getAttribute('srcset') ?? '';
+  expect(srcset, `${where}: srcset 缺少 128 小档`).toContain('w=128');
+  expect(srcset, `${where}: srcset 缺少 256 小档`).toContain('w=256');
+}
+
+describe('logo Image 不再请求 3840px 超大图', () => {
+  it('Navbar logo 应带 sizes="96px" 且 srcset 只含小档位', () => {
+    const { container } = renderWithIntl(<Navbar />);
+    expectLogoUsesSmallSizes(container, 'Navbar');
+  });
+
+  it('Footer logo 应带 sizes="96px" 且 srcset 只含小档位', () => {
+    const { container } = renderWithIntl(<Footer />);
+    expectLogoUsesSmallSizes(container, 'Footer');
+  });
+});


### PR DESCRIPTION
## 背景

GSC 对 `/ja` 的网址检查显示 13 项资源加载失败。逐项评估结论:

- 3 条 challenges.cloudflare.com(Turnstile)「重定向错误」:验证码域对 Googlebot 的挑战行为,第三方、代码无硬依赖,无法也无需修
- 5 条同源 woff2「其他错误」:next/font 自托管字体的瞬时抓取失败,噪音
- 1 条 `/_next/image?url=%2Flogo.png&w=3840`「其他错误」:**真实性能 bug,本 PR 修复**

## 根因与修复

`Navbar.tsx` / `Footer.tsx` 的 logo `<Image>` 写了 `width={2481}` 但没写 `sizes`,Next 按内在宽度从 deviceSizes 挑档,1x/2x 全落到 **w=3840**;Navbar 版还带 `priority`,等于**全站每页预加载一张 3840px 大图**,而 logo 实际显示仅 ~96px 宽。

两处各加一行 `sizes="96px"`:浏览器/爬虫按 sizes 选档(96px × DPR≤3 → 128/256/384),priority 预加载经 `imageSizes="96px"` 同样落到小档。

## 验证

- 新增 `tests/components/logo-image-sizes.test.tsx`(TDD 先行),全量 **1544 passed | 2 skipped**
- 本地 build + `next start` curl 实测:两处 img 均 `sizes="96px"`;预加载 link 输出 `imageSizes="96px"`

## 不做的事(已对齐)

- Turnstile 懒加载(触碰询盘表单主路径,收益是性能非 SEO,缓做)
- GSC 侧无需任何操作:`/ja` 已编入索引,资源报告不影响收录

🤖 Generated with [Claude Code](https://claude.com/claude-code)